### PR TITLE
Replace jax.lax.select with jnp.where

### DIFF
--- a/jmp/_src/loss_scale.py
+++ b/jmp/_src/loss_scale.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Utilities for loss scaling."""
 
+import warnings
 import dataclasses
 import functools
 from typing import Tuple, TypeVar, Union
@@ -122,12 +123,21 @@ class DynamicLossScale:
 
   def __post_init__(self) -> None:
       err_msg = "Expected floating type for %s, got %s"
-      loss_scale_dtype = jnp.asarray(self.loss_scale).dtype
-      if not jnp.issubdtype(loss_scale_dtype, jnp.floating):
-          raise TypeError(err_msg % ("loss_scale", loss_scale_dtype))
-      min_loss_scale_dtype = jnp.asarray(self.min_loss_scale).dtype
-      if not jnp.issubdtype(min_loss_scale_dtype, jnp.floating):
-          raise TypeError(err_msg % ("min_loss_scale", min_loss_scale_dtype))
+      try:
+        loss_scale_dtype = jnp.asarray(self.loss_scale).dtype
+      except TypeError:
+        pass
+      else:
+        if not jnp.issubdtype(loss_scale_dtype, jnp.floating):
+          warnings.warn(Warning(err_msg % ("loss_scale", loss_scale_dtype)))
+      try:
+        min_loss_scale_dtype = jnp.asarray(self.min_loss_scale).dtype
+      except TypeError:
+        pass
+      else:
+        if not jnp.issubdtype(min_loss_scale_dtype, jnp.floating):
+          warnings.warn(Warning(err_msg % ("min_loss_scale",
+                                           min_loss_scale_dtype)))
 
   def scale(self, tree: T) -> T:
     # usage_logging.log_event(usage_logging.Event.JMP, "DynamicLossScale")

--- a/jmp/_src/loss_scale.py
+++ b/jmp/_src/loss_scale.py
@@ -118,7 +118,16 @@ class DynamicLossScale:
   counter: jnp.ndarray = np.zeros([], np.int32)
   period: int = 2000
   factor: int = 2
-  min_loss_scale: jnp.ndarray = np.ones([], np.int32)
+  min_loss_scale: jnp.ndarray = np.ones([], np.float32)
+
+  def __post_init__(self) -> None:
+      err_msg = "Expected floating type for %s, got %s"
+      loss_scale_dtype = jnp.asarray(self.loss_scale).dtype
+      if not jnp.issubdtype(loss_scale_dtype, jnp.floating):
+          raise TypeError(err_msg % ("loss_scale", loss_scale_dtype))
+      min_loss_scale_dtype = jnp.asarray(self.min_loss_scale).dtype
+      if not jnp.issubdtype(min_loss_scale_dtype, jnp.floating):
+          raise TypeError(err_msg % ("min_loss_scale", min_loss_scale_dtype))
 
   def scale(self, tree: T) -> T:
     # usage_logging.log_event(usage_logging.Event.JMP, "DynamicLossScale")

--- a/jmp/_src/loss_scale_test.py
+++ b/jmp/_src/loss_scale_test.py
@@ -34,9 +34,9 @@ class LossScaleTest(parameterized.TestCase):
       ("StaticLossScale(2)", jmp.StaticLossScale, 2),
       ("StaticLossScale(3)", jmp.StaticLossScale, 3),
       ("StaticLossScale(4)", jmp.StaticLossScale, 4),
-      ("DynamicLossScale(2)", jmp.DynamicLossScale, 2),
-      ("DynamicLossScale(3)", jmp.DynamicLossScale, 3),
-      ("DynamicLossScale(4)", jmp.DynamicLossScale, 4),
+      ("DynamicLossScale(2)", jmp.DynamicLossScale, 2.),
+      ("DynamicLossScale(3)", jmp.DynamicLossScale, 3.),
+      ("DynamicLossScale(4)", jmp.DynamicLossScale, 4.),
   )
   def test_static_loss_scale(self, cls, scale):
     loss_scale = cls(scale)
@@ -98,7 +98,7 @@ class LossScaleTest(parameterized.TestCase):
       self.assertEqual(loss_scale.period, period)
       self.assertEqual(loss_scale.factor, factor)
 
-  @parameterized.parameters((20, 2, .3125), (30, 3, .37), (5, 2, 0))
+  @parameterized.parameters((20, 2, .3125), (30, 3, .37), (5., 2., 0.))
   def test_dynamic_loss_scale_explicit_min_loss_scale(self, period, factor,
                                                       min_loss_scale):
     grads_finite = jnp.bool_(False)

--- a/jmp/_src/loss_scale_test.py
+++ b/jmp/_src/loss_scale_test.py
@@ -121,11 +121,13 @@ class LossScaleTest(parameterized.TestCase):
     pass
 
   def test_dynamic_loss_scale_raises_type_error_on_int_loss_scale(self):
-    with self.assertRaises(TypeError):
+    expected_message = "Expected floating type for loss_scale"
+    with self.assertWarnsRegex(Warning, expected_message):
       jmp.DynamicLossScale(jnp.asarray(1, dtype=jnp.int32))
 
   def test_dynamic_loss_scale_raises_type_error_on_int_min_loss_scale(self):
-    with self.assertRaises(TypeError):
+    expected_message = "Expected floating type for min_loss_scale"
+    with self.assertWarnsRegex(Warning, expected_message):
       jmp.DynamicLossScale(jnp.asarray(1, dtype=jnp.float32),
                            min_loss_scale=jnp.asarray(1, dtype=jnp.int32))
 

--- a/jmp/_src/loss_scale_test.py
+++ b/jmp/_src/loss_scale_test.py
@@ -120,6 +120,15 @@ class LossScaleTest(parameterized.TestCase):
   def test_dynamic_loss_scale_adjust_requires_scalar_input(self):
     pass
 
+  def test_dynamic_loss_scale_raises_type_error_on_int_loss_scale(self):
+    with self.assertRaises(TypeError):
+      jmp.DynamicLossScale(jnp.asarray(1, dtype=jnp.int32))
+
+  def test_dynamic_loss_scale_raises_type_error_on_int_min_loss_scale(self):
+    with self.assertRaises(TypeError):
+      jmp.DynamicLossScale(jnp.asarray(1, dtype=jnp.float32),
+                           min_loss_scale=jnp.asarray(1, dtype=jnp.int32))
+
   @parameterized.parameters(jnp.inf, jnp.nan)
   def test_all_finite(self, non_finite):
     self.assertTrue(jmp.all_finite(None))


### PR DESCRIPTION
Thanks for the awesome work!

This PR fixes an issue where `jax.lax.select` complains about dtypes not being equal when adjusting the `DynamicLossScale`. 

The exception's stack trace ends with:
```
File ".../jmp/_src/loss_scale.py", line 147, in adjust
    loss_scale = jax.lax.select(
TypeError: lax.select requires arguments to have the same dtypes, got float32, int32. (Tip: jnp.where is a similar function that does automatic type promotion on inputs).
```

My code looks similar to 
```python3
scale = jmp.DynamicLossScale(jnp.asarray(2 ** 15))
...
gradients, scale = gradient_fn(..., scale)
gradients = scale.unscale(gradients)
gradients_finite = jmp.all_finite(gradients)
scale = scale.adjust(gradients_finite)  # This line throws the exception
...
```