### PR TITLE
Fix dataclass use failure on Python 3.11

### DIFF
--- a/jmp/_src/loss_scale.py
+++ b/jmp/_src/loss_scale.py
@@ -115,10 +115,12 @@ class DynamicLossScale:
   ...   # conditionally update params using grads
   """
   loss_scale: jnp.ndarray
-  counter: jnp.ndarray = np.zeros([], np.int32)
+  counter: jnp.ndarray = dataclasses.field(
+    default_factory=lambda: jnp.zeros([], jnp.int32))
   period: int = 2000
   factor: int = 2
-  min_loss_scale: jnp.ndarray = np.ones([], np.int32)
+  min_loss_scale: jnp.ndarray = dataclasses.field(
+    default_factory=lambda: jnp.ones([], jnp.int32))
 
   def scale(self, tree: T) -> T:
     # usage_logging.log_event(usage_logging.Event.JMP, "DynamicLossScale")


### PR DESCRIPTION
On Python 3.11 dataclasses crashes due to mutable default values. Updated to use default_factory instead.