### PR TITLE
Update loss_scale.py

### DIFF
--- a/jmp/_src/loss_scale.py
+++ b/jmp/_src/loss_scale.py
@@ -136,15 +136,15 @@ class DynamicLossScale:
     return jax.tree_util.tree_map(lambda x: x * inv_loss_scale, tree)
 
   def tree_flatten(self) -> Tuple[_Data, _Meta]:
-    data = (self.loss_scale, self.counter)
+    data = (self.loss_scale, self.counter, self.min_loss_scale)
     meta = (self.period, self.factor)
     return data, meta
 
   @classmethod
   def tree_unflatten(cls, meta: _Meta, data: _Data) -> "DynamicLossScale":
-    loss_scale, counter = data
+    loss_scale, counter, min_loss_scale = data
     period, factor = meta
-    return cls(loss_scale, counter, period, factor)
+    return cls(loss_scale, counter, period, factor, min_loss_scale)
 
   def adjust(self, grads_finite: jnp.ndarray) -> "DynamicLossScale":
     """Returns the next state dependent on whether grads are finite."""


### PR DESCRIPTION
DynamicLossScale.min_loss_scale isn't passed in the DynamicLossScale.tree_flatten outputs which triggered the default factory when calling DynamicLossScale.tree_unflatten. Potentially changing the dtype while doing so (and of course, not keeping the original value).